### PR TITLE
Update NationalParks.csproj for Tekton Pipelines in OCP Demo

### DIFF
--- a/NationalParks.csproj
+++ b/NationalParks.csproj
@@ -1,13 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="MongoDB.Driver" Version="2.11.5" />
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
   </ItemGroup>
-
 
 </Project>


### PR DESCRIPTION
Currently the pipeline in the [CI page](https://redhat-scholars.github.io/openshift-starter-guides-dotnet/rhs-openshift-starter-guides-dotnet/4.6/nationalparks-dotnet-pipeline.html#explore_pipeline) of the OpenShift starter guide isn't working because the ClusterTask requires .NET 7, fixing this repo to allow this.