### PR TITLE
Update NationalParks.csproj

### DIFF
--- a/NationalParks.csproj
+++ b/NationalParks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net7.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Just hit a problem with a customer doing the workshop. 

/usr/lib64/dotnet/sdk/5.0.214/Sdks/Microsoft.NET.Sdk/targets/Microsoft.NET.TargetFrameworkInference.targets(141,5): error NETSDK1045: The current .NET SDK does not support targeting .NET 7.0.  Either target .NET 5.0 or lower, or use a version of the .NET SDK that supports .NET 7.0. [/opt/app-root/src/NationalParks.csproj]

The change committed here fixed the problem.