### PR TITLE
Update NationalParks.csproj for target framework version .net6

### DIFF
--- a/NationalParks.csproj
+++ b/NationalParks.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Updated .net target framework version to 6. ARO's S2I as of April 2024 does not have .net framework 5.0 version supported. 